### PR TITLE
.github: Run r2c.registry.latest via Bento Action

### DIFF
--- a/.bento/config.yml
+++ b/.bento/config.yml
@@ -1,0 +1,19 @@
+autorun:
+  block: true
+formatter:
+- clippy: {}
+tools:
+  hadolint:
+    ignore:
+    - DL3008
+    - DL3010
+    - DL3012
+    - DL3018
+    - DL3020
+    - DL3022
+    - DL3027
+    - DL4001
+    run: true
+  r2c.registry.latest:
+    ignore: []
+    run: true

--- a/.bentoignore
+++ b/.bentoignore
@@ -1,0 +1,55 @@
+# Items added to this file will be ignored by bento.
+#
+# This file uses .gitignore syntax:
+#
+# To ignore a file anywhere it occurs in your project, enter a
+# glob pattern here. E.g. "*.min.js".
+#
+# To ignore a directory anywhere it occurs in your project, add
+# a trailing slash to the file name. E.g. "dist/".
+#
+# To ignore a file or directory only relative to the project root,
+# include a slash anywhere except the last character. E.g.
+# "/dist/", or "src/generated".
+#
+# Some parts of .gitignore syntax are not supported, and patterns
+# using this syntax will be dropped from the ignore list:
+# - Explicit "include syntax", e.g. "!kept/".
+# - Multi-character expansion syntax, e.g. "*.py[cod]"
+#
+# To include ignore patterns from another file, start a line
+# with ':include', followed by the path of the file. E.g.
+# ":include path/to/other/ignore/file".
+#
+# To ignore a file with a literal ':' character, escape it with
+# a backslash, e.g. "\:foo".
+
+# Ignore Bento environment files
+.bento/
+
+# Ignore git items
+.gitignore
+.git/
+# Ignore node packaging directories
+node_modules/
+packages/
+
+# Ignore Python packaging directories
+__pycache__/
+build/
+develop-eggs/
+dist/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+
+# Ignore mypy stuff
+.mypy_cache/

--- a/.github/workflows/bento.yml
+++ b/.github/workflows/bento.yml
@@ -1,0 +1,15 @@
+jobs:
+  bento:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - id: bento
+      name: Bento
+      uses: returntocorp/bento-action@v1
+      with:
+        acceptTermsWithEmail: bence@underyx.me
+        slackWebhookURL: ${{ secrets.BENTO_SLACK_WEBHOOK_URL }}
+name: Bento
+'on':
+- pull_request

--- a/.github/workflows/bento.yml
+++ b/.github/workflows/bento.yml
@@ -8,7 +8,7 @@ jobs:
       name: Bento
       uses: returntocorp/bento-action@v1
       with:
-        acceptTermsWithEmail: bence@underyx.me
+        acceptTermsWithEmail: test@returntocorp.com
         slackWebhookURL: ${{ secrets.BENTO_SLACK_WEBHOOK_URL }}
 name: Bento
 'on':


### PR DESCRIPTION
This commit:

 - Adds the Bento Action as a new workflow if needed

 - Sets up Slack notifications on failure

 - Enables the r2c.registry.latest tool in the Bento config

Relates to https://github.com/returntocorp/enterprise/issues/19
